### PR TITLE
Only allow messages from range of exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /vendor/
 composer.lock
 coverage.xml
+coverage.clover

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /vendor/
 composer.lock
 coverage.xml
-coverage.clover

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -3,6 +3,7 @@
 namespace SumoCoders\FrameworkErrorBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\FlattenException;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
@@ -20,9 +21,11 @@ class ExceptionController extends Controller
         FlattenException $exception,
         DebugLoggerInterface $logger = null
     ) {
-        $message = 'Something went wrong.';
+        /** @var Translator $translator */
+        $translator = $this->get('translator');
+        $message = $translator->trans('error.messages.generic');
         if ('Symfony\Component\HttpKernel\Exception\NotFoundHttpException' == $exception->getClass()) {
-            $message = $exception->getMessage();
+            $message = $translator->trans('error.messages.noRouteFound');
         }
 
         return $this->render(

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -9,6 +9,12 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 
 class ExceptionController extends Controller
 {
+    /**
+     * @param Request              $request
+     * @param FlattenException     $exception
+     * @param DebugLoggerInterface $logger
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     public function showExceptionAction(
         Request $request,
         FlattenException $exception,

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -20,14 +20,17 @@ class ExceptionController extends Controller
         FlattenException $exception,
         DebugLoggerInterface $logger = null
     ) {
-        $data = array(
-            'status_code' => $exception->getStatusCode(),
-            'status_text' => $exception->getMessage(),
-        );
+        $message = 'Something went wrong.';
+        if ('Symfony\Component\HttpKernel\Exception\NotFoundHttpException' == $exception->getClass()) {
+            $message = $exception->getMessage();
+        }
 
         return $this->render(
             '::error.html.twig',
-            $data
+            array(
+                'status_code' => $exception->getStatusCode(),
+                'status_text' => $message
+            )
         );
     }
 }

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -24,6 +24,16 @@ class ExceptionController extends Controller
         /** @var Translator $translator */
         $translator = $this->get('translator');
         $message = $translator->trans('error.messages.generic');
+
+        // check if the error is whitelisted to overrule the message
+        if (in_array(
+            '\\' . $exception->getClass(),
+            $this->container->getParameter('sumo_coders_framework_error.show_messages_for')
+        )) {
+            $message = $exception->getMessage();
+        }
+
+        // translate page not found messages
         if ('Symfony\Component\HttpKernel\Exception\NotFoundHttpException' == $exception->getClass()) {
             $message = $translator->trans('error.messages.noRouteFound');
         }

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -27,7 +27,7 @@ class ExceptionController extends Controller
 
         // check if the error is whitelisted to overrule the message
         if (in_array(
-            '\\' . $exception->getClass(),
+            $exception->getClass(),
             $this->container->getParameter('sumo_coders_framework_error.show_messages_for')
         )) {
             $message = $exception->getMessage();
@@ -42,7 +42,7 @@ class ExceptionController extends Controller
             '::error.html.twig',
             array(
                 'status_code' => $exception->getStatusCode(),
-                'status_text' => $message
+                'status_text' => $message,
             )
         );
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SumoCoders\FrameworkErrorBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('sumo_coders_framework_error');
+
+        $rootNode
+            ->children()
+                ->arrayNode('show_messages_for')
+                    ->prototype('scalar')
+                    ->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/DependencyInjection/SumoCodersFrameworkErrorExtension.php
+++ b/DependencyInjection/SumoCodersFrameworkErrorExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SumoCoders\FrameworkErrorBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
+
+class SumoCodersFrameworkErrorExtension extends ConfigurableExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
+    {
+        $showMessagesFor = array();
+
+        if (isset($mergedConfig['show_messages_for'])) {
+            $showMessagesFor = array_unique($mergedConfig['show_messages_for']);
+        }
+
+        // store the configuration in the messages
+        $container->setParameter(
+            'sumo_coders_framework_error.show_messages_for',
+            $showMessagesFor
+        );
+    }
+}

--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -4,7 +4,7 @@ eo_airbrake:
 
 sumo_coders_framework_error:
   show_messages_for:
-    - \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+    - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
 
 services:
   sumocoders_framework_error_bundle.twig.notifier_extension:

--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -2,6 +2,10 @@ eo_airbrake:
   api_key: "%errbit_api_key%"
   host: errors.sumocoders.be
 
+sumo_coders_framework_error:
+  show_messages_for:
+    - \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+
 services:
   sumocoders_framework_error_bundle.twig.notifier_extension:
     class: SumoCoders\FrameworkErrorBundle\Twig\NotifierExtension

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -56,7 +56,7 @@ By default a generic message will be shown. But if you want you can change this
 # Allow some exceptions to expose their message
 sumo_coders_framework_error:
   show_messages_for:
-    - \Your\Own\Exception
+    - Your\Own\Exception
 ```
 
 Once this is configured the message will be grabbed through `getMessage()` on 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -1,5 +1,8 @@
 # Getting Started With FrameworkErrorBundle
 
+The FrameworkErrorBundle will show a nicely styled error-page when an exception
+occurs and send the real exception to Errbit.
+
 ## Installation
 
 Add FrameworkErrorBundle as a requirement in your composer.json:
@@ -41,4 +44,20 @@ Add the custom exception controller into `app/config/config_prod.yml`
 twig:
     exception_controller: SumoCodersFrameworkErrorBundle:Exception:showException
 ```
+
 Fill in the `errbit_api_key` in your `parameters.yml`.
+
+## Show specific messages
+
+By default a generic message will be shown. But if you want you can change this
+ for some specific exceptions by white-listing them.
+
+```yaml
+# Allow some exceptions to expose their message
+sumo_coders_framework_error:
+  show_messages_for:
+    - \Your\Own\Exception
+```
+
+Once this is configured the message will be grabbed through `getMessage()` on 
+your exception.

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -1,0 +1,4 @@
+error:
+  messages:
+    generic: Something went wrong.
+    noRouteFound: Page not found.

--- a/Resources/translations/messages.nl.yml
+++ b/Resources/translations/messages.nl.yml
@@ -1,0 +1,4 @@
+error:
+  messages:
+    generic: Er ging iets mis.
+    noRouteFound: De pagina werd niet gevonden.

--- a/Tests/Controller/App/config.yml
+++ b/Tests/Controller/App/config.yml
@@ -20,6 +20,7 @@ framework:
     engines: ['twig']
   session:
       storage_id: session.storage.filesystem
+  translator: { fallback: "en" }
 
 monolog:
   handlers:

--- a/Tests/Controller/ExceptionControllerTest.php
+++ b/Tests/Controller/ExceptionControllerTest.php
@@ -20,7 +20,7 @@ class DefaultControllerTest extends WebTestCase
         $client = static::createClient();
         $crawler = $client->request('GET', '/exception/standard');
 
-        $this->assertErrorPage($client, $crawler, 500, 'This is a standard exception.');
+        $this->assertErrorPage($client, $crawler, 500);
     }
 
     /**
@@ -35,7 +35,7 @@ class DefaultControllerTest extends WebTestCase
         Client $client,
         Crawler $crawler,
         $code,
-        $message
+        $message = 'Something went wrong.'
     ) {
         // check if the code is set correctly
         $this->assertEquals($code, $client->getResponse()->getStatusCode());

--- a/Tests/Controller/ExceptionControllerTest.php
+++ b/Tests/Controller/ExceptionControllerTest.php
@@ -12,7 +12,7 @@ class DefaultControllerTest extends WebTestCase
         $client = static::createClient();
         $crawler = $client->request('GET', '/non-existing-path');
 
-        $this->assertErrorPage($client, $crawler, 404, 'No route found for "GET /non-existing-path"');
+        $this->assertErrorPage($client, $crawler, 404, 'Page not found.');
     }
 
     public function testStandardException()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SumoCoders\FrameworkErrorBundle\Tests\DependencyInjection;
+
+use SumoCoders\FrameworkErrorBundle\DependencyInjection\Configuration;
+use SumoCoders\FrameworkErrorBundle\DependencyInjection\SumoCodersFrameworkErrorExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SumoCodersFrameworkErrorExtension
+     */
+    protected $extension;
+
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    public function setUp()
+    {
+        $this->extension = new SumoCodersFrameworkErrorExtension();
+        $this->configuration = new Configuration();
+    }
+
+    public function tearDown()
+    {
+        $this->configuration = null;
+    }
+
+    public function testDefaultConfig()
+    {
+        $container = new ContainerBuilder();
+        $this->extension->load(array(), $container);
+
+        $this->assertTrue($container->hasParameter('sumo_coders_framework_error.show_messages_for'));
+        $this->assertEmpty($container->getParameter('sumo_coders_framework_error.show_messages_for'));
+    }
+}

--- a/Tests/Twig/NotifierExtensionTest.php
+++ b/Tests/Twig/NotifierExtensionTest.php
@@ -40,10 +40,9 @@ class NotifierExtensionTest extends \PHPUnit_Framework_TestCase
         $var = $this->extension->getFunctions();
 
         $this->assertInternalType('array', $var);
-        $this->assertArrayHasKey('errbit_notifier', $var);
         $this->assertInstanceOf(
-            '\Twig_Function_Method',
-            $var['errbit_notifier']
+            '\Twig_SimpleFunction',
+            $var[0]
         );
     }
 

--- a/Twig/NotifierExtension.php
+++ b/Twig/NotifierExtension.php
@@ -42,9 +42,9 @@ class NotifierExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'errbit_notifier' => new \Twig_Function_Method(
-                $this,
-                'getErrbitNotifier',
+            new \Twig_SimpleFunction(
+                'errbit_notifier',
+                array($this, 'getErrbitNotifier'),
                 array(
                     'is_safe' => array('html'),
                 )


### PR DESCRIPTION
As Doctrine will include some sensitive data

A possible solution is to whitelist some classes (thru the configuration) that are allowed to expose the messages. If the exception isn't an instance of one of the configured classes a generic message should be shown.
- [x] Allow 404 by default, all other exceptions should show a generic message
- [x] Make the generic message translatable
- [x] Allow to configure the allowed exceptions
