### PR TITLE
Show exceptions when something goes wrong in cli commands. Fixes #6

### DIFF
--- a/Listener/ConsoleExceptionListener.php
+++ b/Listener/ConsoleExceptionListener.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SumoCoders\FrameworkErrorBundle\Listener;
+
+use Eo\AirbrakeBundle\Bridge\Client;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+
+/**
+ * Catches console exceptions and sends them to errbit
+ */
+class ConsoleExceptionListener
+{
+    /**
+     * @var Airbrake\Client
+     */
+    protected $client;
+
+    /**
+     * Class constructor
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function onConsoleException(ConsoleExceptionEvent $event)
+    {
+        $exception = $event->getException();
+        $this->client->notifyOnException($exception);
+        error_log($exception->getMessage().' in: '.$exception->getFile().':'.$exception->getLine());
+    }
+}

--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -15,3 +15,9 @@ services:
       - @twig
       - %eo_airbrake.host%
       - %eo_airbrake.api_key%
+  sumocoders_console_error_handler:
+    class: SumoCoders\FrameworkErrorBundle\Listener\ConsoleExceptionListener
+    tags:
+      - { name: kernel.event_listener, event: console.exception, method: onConsoleException }
+    arguments:
+      - @eo_airbrake.client


### PR DESCRIPTION
We use the cli commands in cronjobs, and want to be notified using our
error handling system, not through crontab mails.
